### PR TITLE
refactor(coding): move comment setup to ts-context

### DIFF
--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -7,14 +7,12 @@ return {
 		config = function()
 			require("mini.ai").setup()
 			require("mini.bracketed").setup()
-			require("mini.comment").setup()
 			require("mini.move").setup()
 			require("mini.sessions").setup()
 			require("mini.starter").setup()
 			require("mini.surround").setup()
 
 			local toggle_key = "<leader>t"
-
 			require("mini.basics").setup({
 				mappings = {
 					windows = true,


### PR DESCRIPTION
- can lazy load both at the same time
- allow rest of mini to load immediately