### PR TITLE
feat(autocmds): remove close with q

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -15,16 +15,6 @@ vim.api.nvim_create_autocmd("FileType", {
 	end,
 })
 
--- Close some filetypes with <q>
-vim.api.nvim_create_autocmd("FileType", {
-	group = augroup("close_with_q"),
-	pattern = { "help", "fugitive", "qf" },
-	callback = function(event)
-		vim.bo[event.buf].buflisted = false
-		vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })
-	end,
-})
-
 -- Auto create dir when saving a file, in case some intermediate directory does not exist
 vim.api.nvim_create_autocmd({ "BufWritePre" }, {
 	group = augroup("auto_create_dir"),


### PR DESCRIPTION
- inconsistency with some file types
- better to use :q with everything